### PR TITLE
UIAElement Methods which could return 0 or false weren't working

### DIFF
--- a/assertions.js
+++ b/assertions.js
@@ -214,7 +214,7 @@ function assertPropertiesMatch(expected, given, level) {
           continue;
         }
 
-        if (!givenProp) {
+        if (givenProp == null) {
           throw propName;
         }
 


### PR DESCRIPTION
As discussed on Twitter there was an issue with functions returning 0 or false in assertPropertiesMatch which raised a false exception. 
