### PR TITLE
Added vtap to wait for element become visible and tap

### DIFF
--- a/uiautomation-ext.js
+++ b/uiautomation-ext.js
@@ -172,7 +172,9 @@ TODO: Character keyboard is super slow.
 */
 var typeString = function(pstrString, pbClear)
 {
-    if (!this.hasKeyboardFocus())
+	pstrString += ''; // convert number to string 
+	
+	if (!this.hasKeyboardFocus())
         this.tap();
 
     UIATarget.localTarget().delay(0.5);


### PR DESCRIPTION
By default, I have to add a lot of delay() before tap() in order to wait for element to become visible.

Added vtap() to wait for element become visible and tap

See this blog:
http://blog.airsource.co.uk/index.php/2010/08/13/ui-automation-on-the-iphone/
