### PR TITLE
Fix matching of properties against RegExp objects

### DIFF
--- a/assertions.js
+++ b/assertions.js
@@ -298,6 +298,9 @@ function assertPropertiesMatch(expected, given, level) {
               assertPropertiesMatch(exp, giv, level + 1);
             }
           }
+          else if (expectedProp.constructor === RegExp) {
+            assertMatch(expectedProp, givenProp);
+          }
           else if (typeof(givenProp) == "object") {
             assertPropertiesMatch(expectedProp, givenProp, level + 1);
           }


### PR DESCRIPTION
RegExp's need to be handled in the object-handling path of assertPropertiesMatch() because typeof(new RegExp()) == 'object'. Tested with Instruments v4.2.
