### PR TITLE
Make assertWindow() use new assertElementTree() so that we can do per element assertions

### DIFF
--- a/assertions.js
+++ b/assertions.js
@@ -102,6 +102,39 @@ function assertNotNull(thingie, message) {
 }
 
 /**
+ * Assert that the given definition matches the given element. The
+ * definition is a JavaScript object whose property hierarchy matches
+ * the given UIAElement.  Property names in the given definition that match a
+ * method will cause that method to be invoked and the matching to be performed
+ * and the result. For example, the UITableView exposes all UITableViewCells through
+ * the cells() method. You only need to specify a 'cells' property to
+ * cause the method to be invoked.
+ */
+function assertElementTree(element, definition) {
+  var onPass = null;
+  if (definition.onPass) {
+    onPass = definition.onPass;
+    delete definition.onPass;
+  }
+
+  try {
+    assertPropertiesMatch(definition, element, 0);
+  }
+  catch(badProp) {
+    fail("Failed to match " + badProp[0] + ": " + badProp[1]);
+  }
+
+  if (onPass) {
+    try {
+      onPass(element);
+    }
+    catch(e) {
+      throw "Failed to execute 'onPass' callback: " + e;
+    }
+  }
+}
+
+/**
  * Assert that the given window definition matches the current main window. The
  * window definition is a JavaScript object whose property hierarchy matches
  * the main UIAWindow.  Property names in the given definition that match a
@@ -197,27 +230,7 @@ function assertWindow(window) {
   application = target.frontMostApp();
   mainWindow = application.mainWindow();
 
-  var onPass = null;
-  if (window.onPass) {
-    onPass = window.onPass;
-    delete window.onPass;
-  }
-
-  try {
-    assertPropertiesMatch(window, mainWindow, 0);
-  }
-  catch(badProp) {
-    fail("Failed to match " + badProp[0] + ": " + badProp[1]);
-  }
-
-  if (onPass) {
-    try {
-      onPass(mainWindow);
-    }
-    catch(e) {
-      throw "Failed to execute 'onPass' callback: " + e;
-    }
-  }
+  assertElementTree(mainWindow, window)
 }
 
 /**


### PR DESCRIPTION
assertWindow() is too high level since it forces you to always assert from the top down, sometimes you just need to assert from a single element down, so I moved the basic logic into assertElementTree() and added a helper assertWindow() function that continues to perform as expected.

This is just a minor re-factoring that will allow for per element assertions so that you don't always have to walk the entire window if you just want to verify some sub-section of it.
