### PR TITLE
Fixed crash on test failure due to logging a raw exception object.

### DIFF
--- a/test.js
+++ b/test.js
@@ -29,7 +29,7 @@ function test(title, f, options) {
     UIALogger.logPass(title);
   }
   catch (e) {
-    UIALogger.logError(e);
+    UIALogger.logError(e.toString());
     if (options.logTree) target.logElementTree();
     UIALogger.logFail(title);
   }


### PR DESCRIPTION
UIALogger methods don't accept objects as parameters.  They must be passed strings or they crash in iOS5.
