### PR TITLE
New functions for picker wheels

### DIFF
--- a/uiautomation-ext.js
+++ b/uiautomation-ext.js
@@ -266,9 +266,6 @@ extend(UIAPickerWheel.prototype, {
    scrollToValue: function (valueToSelect) {
    
       var element = this;      
-      
-      // element.logElementTree();
-      
       var values = this.values();
       var pickerValue = element.value();
       
@@ -283,22 +280,14 @@ extend(UIAPickerWheel.prototype, {
       } else {
         var currentValue = element.value();
       }
-      
-      // DEBUGGING info
-      //UIALogger.logDebug("currentValue: " + currentValue);
-      //UIALogger.logDebug("all Values: " + values);
-      
+            
       var currentValueIndex = values.indexOf(currentValue);
       var valueToSelectIndex = values.indexOf(valueToSelect);
       
       if (valueToSelectIndex == -1) {
         fail("value: " + valueToSelect + " not found in Wheel!");
       }
-      
-      // DEBUGGING info
-      //UIALogger.logDebug("index1: " + currentValueIndex);
-      //UIALogger.logDebug("index2: " + valueToSelectIndex);
-      
+    
       var elementsToScroll = valueToSelectIndex - currentValueIndex;
       
       UIALogger.logDebug("number of elements to scroll: " + elementsToScroll);


### PR DESCRIPTION
Added a function to scroll picker wheels scrollToValue()
- Better implementation than UIAPickerWheel.selectValue(x)
- Works also for texts
- Poorly works not for UIDatePickers -> because .values() which get all values of wheel does not work :(
  (I think this is a bug in UIAutomation!)

Added a function realValue() to get "real" values of picker wheels
- Wheels filled with values return for .value()  "17. 128 of 267" ?? don't know why -> for comparisons this is unuseful!!
- If you want to check a value of a wheel this function is very helpful
