### PR TITLE
More robust run-test

### DIFF
--- a/run-test
+++ b/run-test
@@ -48,7 +48,7 @@ options.env_vars.to_a.each do |pair|
   command << "-e"
   command.concat(pair)
 end
-puts "command=#{command.join ' '}"
+puts "command=" + command.map { |s| s.sub(/\A(.*\s.*)\Z/, '"\1"') }.join(' ')
 
 failed = false
 


### PR DESCRIPTION
- The array version of PTY.spawn is used to avoid problems with spaces in pathnames and related quoting problems.
- Pathnames that need to be absolute are converted using File.expand_path, and tested for existence.
