### PR TITLE
Implemented run-test features #25, #26, #27, #28

### DIFF
--- a/run-test
+++ b/run-test
@@ -149,15 +149,13 @@ Dir.chdir(test_output) do
             w.close
             r.close
             Process.wait(pid)
-          rescue PTY::ChildExited
+          rescue Errno::EIO, EOFError, PTY::ChildExited
           end
           puts "Pid #{pid} killed."
         end
       end
     end
-  rescue Errno::EIO
-  rescue EOFError
-  rescue PTY::ChildExited => e
+  rescue Errno::EIO, EOFError, PTY::ChildExited
     STDERR.puts "Instruments exited unexpectedly"
     exit 1
   end


### PR DESCRIPTION
#25, #26, #27 are straight-forward implementations of run-test features in a separate commit.

Find the bundle file at runtime (Issue #28) is experimental.
Option design and other concerns are discussed in the issues.
