### PR TITLE
Check for config via NOT

### DIFF
--- a/test.js
+++ b/test.js
@@ -16,7 +16,7 @@
  *
  */
 function test(title, f, options) {
-  if (options === null) {
+  if (!options) {
     options = {
       logTree: true
     };


### PR DESCRIPTION
Until yesterday, this was `if (config == null)`, which checks for a certain
falseyness of `config`. This was changed yesterday to `if (config === null)` which
checks if `config` is, in fact, `null`. The problem is that when calling a function
without a parameter, then the paramter is `undefined`. So maybe we should check
for `if (config === undefined)` but I figure its easier and clearer to check
`if (!config)`
