### PR TITLE
Throw objects not primitives

### DIFF
--- a/assertions.js
+++ b/assertions.js
@@ -360,8 +360,9 @@ function assertPropertiesMatch(expected, given, level) {
           } else if (typeof(givenProp) == "object") {
             assertPropertiesMatch(expectedProp, givenProp, level + 1);
           } else {
-            UIALogger.logError("[" + propName + "]: Unknown type of object constructor: " + expectedProp.constructor);
-            throw propName;
+            var message = "[" + propName + "]: Unknown type of object constructor: " + expectedProp.constructor;
+            UIALogger.logError(message);
+            throw new AssertionException(message);
           }
         } else {
           UIALogger.logError("[" + propName + "]: unknown type for expectedProp: " + typeof(expectedProp));


### PR DESCRIPTION
Throwing a Javascript primitive causes the latest Instruments in the App Store to crash.  I've documented that at [Stack Exchange](http://apple.stackexchange.com/questions/69484/unknown-xcode-instruments-crash/72996#72996) .  Throwing an Object allows tests to run and (arguably) can provide better information for a thrown Exception than a primitive.

There are no Tuneup tests to run against my changes and I have none of my own.  However, the changes are relatively small and concise.  I ran 'jslint' against the changes and it has no issues regarding my changes.
