### PR TITLE
Remove dependency on pgrep in test runner, hide Debug output unless verbose option chosen

### DIFF
--- a/test_runner/run
+++ b/test_runner/run
@@ -237,12 +237,14 @@ begin
           _, date, time, tz, status, msg = line.match(/^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}) ([+-]\d{4}) ([^:]+): (.*)$/).to_a
 
           if status
-            status = parse_status(status) if status
-            outputs.each { |output| output.add_status(status, date, time, tz, msg) }
-            statistics[:total] = statistics[:total].to_i + 1 if status == :start
-            statistics[status] = statistics[status].to_i + 1
+            if options.verbose || status != "Debug"
+              status = parse_status(status) if status
+              outputs.each { |output| output.add_status(status, date, time, tz, msg) }
+              statistics[:total] = statistics[:total].to_i + 1 if status == :start
+              statistics[status] = statistics[status].to_i + 1
+            end
           else
-            outputs.each { |output| output.add(line) }
+            outputs.each { |output| output.add(line) } if options.verbose
           end
 
           failed = true if line =~ /Instruments Trace Error/i


### PR DESCRIPTION
Removing pgrep dependency allows people without homebrew and/or proctools to use your excellent test runner. Also modified runner to hide Debug output, because it really adds noise.
