### PR TITLE
Fix incorrect timeout behavior in waitUntil( ) caused by filter function delays

### DIFF
--- a/uiautomation-ext.js
+++ b/uiautomation-ext.js
@@ -233,9 +233,12 @@ extend(UIAElement.prototype, {
               }
           }, Math.max(1, timeoutInSeconds/delay), delay);
         } catch (e) {
-          UIATarget.localTarget().popTimeout();
           throw e;
         }
+        finally {
+          UIATarget.localTarget().popTimeout();
+        }
+
     },
 
   /**


### PR DESCRIPTION
## Issue

`waitUntil( )` does not use a timestamp to end its wait period, it uses a fixed number of retries calculated from the number of seconds to wait and the amount of time between retries.

This causes a problem because the default timeout for things like `.firstWithName( )` is 5 seconds.  This means a "6 second" wait is actually 24 retries at 5.25 seconds each.  
## Proposed Solution

This patch fixes the problem by setting the timeout to zero during the running of the waitUntil function.
## Old Behavior

`widget.waitUntilFoundByName("Some Label", 6)` actually waits 2 minutes and 6 seconds before exiting.
## New Behavior

`widget.waitUntilFoundByName("Some Label", 6)` waits 6 seconds before exiting.
