### PR TITLE
re-apply isNotNil patch that was lost in formatting shuffle

### DIFF
--- a/uiautomation-ext.js
+++ b/uiautomation-ext.js
@@ -280,8 +280,19 @@ extend(UIAElement.prototype, {
   /**
    * A shortcut for waiting an element to become visible and tap.
    */
-  vtap: function () {
-    this.waitUntilVisible(10);
+  vtap: function (timeout) {
+    if (undefined === timeout) timeout = 10;
+    this.waitUntilVisible(timeout);
+    this.tap();
+  },
+
+  /**
+   * A shortcut for scrolling to a visible item and and tap.
+   */
+  svtap: function (timeout) {
+    if (undefined === timeout) timeout = 1;
+    this.scrollToVisible();
+    //this.waitUntilVisible(timeout);
     this.tap();
   },
   /**


### PR DESCRIPTION
Apologies.  This patch re-applies https://github.com/alexvollmer/tuneup_js/commit/7d6dd73015ddd664790ba0174b5b13d294d9ef10 which was accidentally reverted when doing the style fix.
