### PR TITLE
add utility method to determine if we are running on a simulator.

### DIFF
--- a/uiautomation-ext.js
+++ b/uiautomation-ext.js
@@ -415,6 +415,13 @@ extend(UIATarget.prototype, {
   },
 
   /**
+   * Determine if we are running on a simulator.
+   */
+  isSimulator: function() {
+    return this.model().match(/Simulator/) !== null;
+  },
+
+  /**
    * A convenience method for detecting that you're running on an iPad
    */
   isDeviceiPad: function () {


### PR DESCRIPTION
I found I had to vary my test script slightly between target and simulator (found a bug in apple's simulator) but did not see any utility method to detect if I was running on simulator or not.  So I added this feature.  I tried to get pod to point to my own repo without success -- I am new to the pod system.  Whilst manually making the code change here, and also on top of pod 1.01 version of tuneup_js, only the manual edit on top of 1.01 has been tested.

I've never done a git pull request thing before on github -- I hope this information is sufficient for your evaluation.
