### PR TITLE
Minor bugfixes 

### DIFF
--- a/test_runner/run
+++ b/test_runner/run
@@ -200,7 +200,17 @@ end
 SDKROOT = `/usr/bin/xcodebuild -version -sdk iphoneos | grep PlatformPath`.split(":")[1].chomp.sub(/^\s+/, "")
 XCODE_ROOT = `/usr/bin/xcode-select -print-path`.chomp.sub(/^\s+/, "")
 
-TEMPLATE = `[ -f /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Instruments/PlugIns/AutomationInstrument.bundle/Contents/Resources/Automation.tracetemplate ] && echo "#{SDKROOT}/Developer/Library/Instruments/PlugIns/AutomationInstrument.bundle/Contents/Resources/Automation.tracetemplate" || echo "#{XCODE_ROOT}/../Applications/Instruments.app/Contents/PlugIns/AutomationInstrument.bundle/Contents/Resources/Automation.tracetemplate"`.chomp.sub(/^\s+/, "")
+# path is different for Instruments 6.0
+if File.directory? "#{XCODE_ROOT}/../Applications/Instruments.app/Contents/PlugIns/AutomationInstrument.xrplugin/"
+  instruments_folder = "AutomationInstrument.xrplugin";
+else
+  # older instruments path
+  instruments_folder = "AutomationInstrument.bundle";
+end
+
+
+TEMPLATE = `[ -f /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Instruments/PlugIns/#{instruments_folder}/Contents/Resources/Automation.tracetemplate ] && echo "#{SDKROOT}/Developer/Library/Instruments/PlugIns/#{instruments_folder}/Contents/Resources/Automation.tracetemplate" || echo "#{XCODE_ROOT}/../Applications/Instruments.app/Contents/PlugIns/#{instruments_folder}/Contents/Resources/Automation.tracetemplate"`.chomp.sub(/^\s+/, "")
+ 
 
 command = ["env", "DEVELOPER_DIR=#{XCODE_ROOT}", "/usr/bin/instruments"]
 if options.device

--- a/uiautomation-ext.js
+++ b/uiautomation-ext.js
@@ -432,7 +432,7 @@ extend(UIAElement.prototype, {
    */
   waitUntilAccessorSuccess: function (lookup_function, timeoutInSeconds, label) {
     var isNotUseless = function (elem) {
-      return elem !== null && elem.isNotNil();
+      return elem && elem.isNotNil();
     }
 
     // this function will be referenced in waitUntil -- it supplies
@@ -471,7 +471,7 @@ extend(UIAElement.prototype, {
    */
   waitUntilAccessorSelect: function (lookup_functions, timeoutInSeconds) {
     var isNotUseless = function (elem) {
-      return elem !== null && elem.isNotNil();
+      return elem && elem.isNotNil();
     }
 
     // this function will be referenced in waitUntil -- it supplies
@@ -540,7 +540,7 @@ extend(UIAElement.prototype, {
       retry(function () {
         var filteredElement = filterFunction(element);
         if (!conditionFunction(filteredElement)) {
-          if (!(filteredElement !== null && filteredElement.isNotNil())) {
+          if (!(filteredElement && filteredElement.isNotNil())) {
             var label = (filteredElement && filteredElement.label) ? filteredElement.label() : "Element";
             // make simple error message if the element doesn't exist
             throw ([label, "failed", description,

--- a/uiautomation-ext.js
+++ b/uiautomation-ext.js
@@ -32,7 +32,7 @@ extend(UIAElementArray.prototype, {
     var ret = [];
     for (var i = 0; i < this.length; ++i) {
       var elem = this[i];
-      if (elem.isNotNil && elem.isNotNil() && elem.name() && elem.name().match(pattern) !== null) {
+      if (elem && elem.isNotNil && elem.isNotNil() && elem.name() && elem.name().match(pattern) !== null) {
         ret.push(elem);
       }
     }
@@ -45,7 +45,7 @@ extend(UIAElementArray.prototype, {
   firstWithNameRegex: function(pattern) {
     for (var i = 0; i < this.length; ++i) {
       var elem = this[i];
-      if (elem.isNotNil && elem.isNotNil() && elem.name() && elem.name().match(pattern) !== null) return elem;
+      if (elem && elem.isNotNil && elem.isNotNil() && elem.name() && elem.name().match(pattern) !== null) return elem;
     }
     return new UIAElementNil();
   }
@@ -436,7 +436,7 @@ extend(UIAElement.prototype, {
    */
   waitUntilAccessorSuccess: function (lookup_function, timeoutInSeconds, label) {
     var isNotUseless = function (elem) {
-      return elem && elem.isNotNil();
+      return elem && elem.isNotNil && elem.isNotNil();
     }
 
     // this function will be referenced in waitUntil -- it supplies
@@ -475,7 +475,7 @@ extend(UIAElement.prototype, {
    */
   waitUntilAccessorSelect: function (lookup_functions, timeoutInSeconds) {
     var isNotUseless = function (elem) {
-      return elem && elem.isNotNil();
+      return elem && elem.isNotNil && elem.isNotNil();
     }
 
     // this function will be referenced in waitUntil -- it supplies

--- a/uiautomation-ext.js
+++ b/uiautomation-ext.js
@@ -486,31 +486,34 @@ extend(UIAElement.prototype, {
     }
 
     // composite find function
-    var find_any = function (element) {
+    var find_all = function (element) {
+      var ret = {};
       for (var k in lookup_functions) {
         var lookup_function = lookup_functions[k];
         try {
           var el = lookup_function(element);
-          if (isNotUseless(el)) return {key: k, elem: el};
+          if (isNotUseless(el)) {
+            ret[k] = el;
+          }
         }
         catch (e) {
           // ignore
         }
       }
-      return new UIAElementNil();
+      return ret;
     };
 
     this.waitUntil(function (element) {
-        var result = find_any(element);
-        if (undefined !== result) return result["elem"];
+        var result = find_all(element);
+        for (var k in result) return result[k]; // just returning the first element will signal completion
 
-        // annotate the found elements with the label function if they are nil
+        // no elements, found, so create a fake element and annotate it with a label function
         var fakeNil = new UIAElementNil();
         if (label !== undefined) fakeNil.label = label_fn;
         return fakeNil;
       }, isNotUseless,
       timeoutInSeconds, "to produce any acceptable return values");
-    return find_any(this);
+    return find_all(this);
   },
 
 

--- a/uiautomation-ext.js
+++ b/uiautomation-ext.js
@@ -189,7 +189,11 @@ extend(UIAElement.prototype, {
   /**
    * Find function
    *
-   * Find elements by given criteria
+   * Find elements by given criteria.  Known criteria options are:
+   *  * UIAtype: the class name of the UIAElement
+   *  * nameRegex: a regular expression that will be applied to the name() method
+   *  * rect, hasKeyboardFocus, isEnabled, isValid, label, name, value:
+   *        these correspond to the values of the UIAelement methods of the same names.
    *
    * Return associative array {accessor: element} of results
    */

--- a/uiautomation-ext.js
+++ b/uiautomation-ext.js
@@ -202,7 +202,7 @@ extend(UIAElement.prototype, {
     var visibleOnly = criteria.isVisible === true;
 
     var knownOptions = {UIAtype: 1, rect: 1, hasKeyboardFocus: 1, isEnabled: 1, isValid: 1,
-                        label: 1, name: 1, nameRegex: 1, value: 1};
+                        label: 1, name: 1, nameRegex: 1, value: 1, isVisible: 1};
 
     // helpful check, mostly catching capitalization errors
     for (var k in criteria) {
@@ -214,6 +214,7 @@ extend(UIAElement.prototype, {
     }
 
     var c = criteria;
+    // don't consider isVisible here, because we do it in this._reduce
     var collect_fn = function(acc, elem, prefix, _) {
       if (c.UIAtype !== undefined && "[object " + c.UIAtype + "]" != elem.toString()) return acc;
       if (c.rect !== undefined && JSON.stringify(c.rect) != JSON.stringify(elem.rect())) return acc;

--- a/uiautomation-ext.js
+++ b/uiautomation-ext.js
@@ -45,7 +45,10 @@ extend(UIAElementArray.prototype, {
   firstWithNameRegex: function(pattern) {
     for (var i = 0; i < this.length; ++i) {
       var elem = this[i];
-      if (elem && elem.isNotNil && elem.isNotNil() && elem.name() && elem.name().match(pattern) !== null) return elem;
+      if (elem && elem.isNotNil && elem.isNotNil() && elem.name()) {
+          if (elem.name().match(pattern) !== null) return elem;
+          UIALogger.logDebug("firstWithNameRegex decided that " + pattern + " did not match elem with name = " + elem.name());
+      }
     }
     return new UIAElementNil();
   }
@@ -558,7 +561,7 @@ extend(UIAElement.prototype, {
       retry(function () {
         var filteredElement = filterFunction(element);
         if (!conditionFunction(filteredElement)) {
-          if (!(filteredElement && filteredElement.isNotNil())) {
+          if (!(filteredElement && filteredElement.isNotNil && filteredElement.isNotNil())) {
             var label = (filteredElement && filteredElement.label) ? filteredElement.label() : "Element";
             // make simple error message if the element doesn't exist
             throw ([label, "failed", description,

--- a/uiautomation-ext.js
+++ b/uiautomation-ext.js
@@ -517,7 +517,18 @@ extend(UIAElement.prototype, {
         return fakeNil;
       }, isNotUseless,
       timeoutInSeconds, "to produce any acceptable return values");
-    return find_all(this);
+
+      // repeat the find to return the found elements.
+      // we need to reinstate the timeout since some elements might not be found, and would delay things
+      try {
+        UIATarget.localTarget().pushTimeout(0);
+        return find_all(this);
+      } catch (e) {
+        UIALogger.logDebug("waitUntilAccessorSelect encountered error the 2nd time running find_all: " + e);
+        throw e;
+      } finally {
+        UIATarget.localTarget().popTimeout();
+      }
   },
 
 

--- a/uiautomation-ext.js
+++ b/uiautomation-ext.js
@@ -47,7 +47,6 @@ extend(UIAElementArray.prototype, {
       var elem = this[i];
       if (elem && elem.isNotNil && elem.isNotNil() && elem.name()) {
           if (elem.name().match(pattern) !== null) return elem;
-          UIALogger.logDebug("firstWithNameRegex decided that " + pattern + " did not match elem with name = " + elem.name());
       }
     }
     return new UIAElementNil();

--- a/uiautomation-ext.js
+++ b/uiautomation-ext.js
@@ -32,7 +32,7 @@ extend(UIAElementArray.prototype, {
     var ret = [];
     for (var i = 0; i < this.length; ++i) {
       var elem = this[i];
-      if (elem.isNotNil && elem.isNotNil() && elem.name().match(pattern) !== null) {
+      if (elem.isNotNil && elem.isNotNil() && elem.name() && elem.name().match(pattern) !== null) {
         ret.push(elem);
       }
     }
@@ -45,7 +45,7 @@ extend(UIAElementArray.prototype, {
   firstWithNameRegex: function(pattern) {
     for (var i = 0; i < this.length; ++i) {
       var elem = this[i];
-      if (elem.isNotNil && elem.isNotNil() && elem.name().match(pattern) !== null) return elem;
+      if (elem.isNotNil && elem.isNotNil() && elem.name() && elem.name().match(pattern) !== null) return elem;
     }
     return new UIAElementNil();
   }


### PR DESCRIPTION
- Suppressed a warning that wasn't valid
- Handle `undefined` and `null` together and more elegantly
- Fix `.waitUntilAccessorSelect()` so that it returns all results, not just the first one (in line with Unix `select()`)
