### PR TITLE
Fixes re waitUntilAccessorSelect:

### DIFF
--- a/uiautomation-ext.js
+++ b/uiautomation-ext.js
@@ -508,7 +508,7 @@ extend(UIAElement.prototype, {
 
     this.waitUntil(function (element) {
         var result = find_any(element);
-        if (undefined !== result && result.isNotNil()) {  //find_any() will return UIAElementNilSingleton if not found and we don't want to start processing that-especially not result["elem"]
+        if (undefined !== result && result !== UIAElementNilSingleton) {  //find_any() will return UIAElementNilSingleton if not found and we don't want to start processing that-especially not result["elem"]
 	      successfulResult = result;
 	      return result["elem"];
         } 


### PR DESCRIPTION
We cannot instantiate UIAElementNil and still have our extensions work so we hold onto a Singleton.  We also need to ensure that we gently handle find_any() when it fails to find anything. Using a singleton means we can no longer annotate a UIAElementNil for error reporting.
