### PR TITLE
Fixed bug in withNameRegex and firstWithNameRegex when name is null

### DIFF
--- a/uiautomation-ext.js
+++ b/uiautomation-ext.js
@@ -35,7 +35,7 @@ extend(UIAElementArray.prototype, {
     var ret = [];
     for (var i = 0; i < this.length; ++i) {
       var elem = this[i];
-      if (elem.isNotNil && elem.isNotNil() && elem.name().match(pattern) !== null) {
+      if (elem.isNotNil && elem.isNotNil() && elem.name() && elem.name().match(pattern) !== null) {
         ret.push(elem);
       }
     }
@@ -48,7 +48,7 @@ extend(UIAElementArray.prototype, {
   firstWithNameRegex: function(pattern) {
     for (var i = 0; i < this.length; ++i) {
       var elem = this[i];
-      if (elem.isNotNil && elem.isNotNil() && elem.name().match(pattern) !== null) return elem;
+      if (elem.isNotNil && elem.isNotNil() && elem.name() && elem.name().match(pattern) !== null) return elem;
     }
     return new UIAElementNil();
   }


### PR DESCRIPTION
This is a small bug fix for the functions withNameRegex and firstWithNameRegex.

When there are elements in the iterated array where the name is null, I got the following error:
TypeError: undefined is not a function (evaluating 'elem.name().match')

So I included a check if the name exists by calling the name() function as an additional condition.
