### PR TITLE
Fix start-up delay when creating nil singleton.

### DIFF
--- a/uiautomation-ext.js
+++ b/uiautomation-ext.js
@@ -2,7 +2,9 @@
 #import "lang-ext.js";
 
 //We cannot instantiate a UIAElementNil and still get our extensions, so we hold onto one.
-UIAElementNilSingleton =  UIATarget.localTarget().frontMostApp().mainWindow().staticTexts().firstWithName("notFoundx123hfhfhfhfhfhed");
+UIATarget.localTarget().pushTimeout(1);
+UIAElementNilSingleton = UIATarget.localTarget().frontMostApp().mainWindow().staticTexts().firstWithName("notFoundx123hfhfhfhfhfhed");
+UIATarget.localTarget().popTimeout();
 
 extend(UIATableView.prototype, {
   /**


### PR DESCRIPTION
We have been experiencing a large delay upon launching the application since the 1.2.3 update.

The NilSingleton element will never be found so there is no need to wait for the default timeout duration.
